### PR TITLE
Fix NullPointerException in USB attachment logging

### DIFF
--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
@@ -212,7 +212,8 @@ public class FtcRobotControllerActivity extends Activity
 
     if (UsbManager.ACTION_USB_DEVICE_ATTACHED.equals(intent.getAction())) {
       UsbDevice usbDevice = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
-      RobotLog.vv(TAG, "ACTION_USB_DEVICE_ATTACHED: %s", usbDevice.getDeviceName());
+      RobotLog.vv(TAG, "ACTION_USB_DEVICE_ATTACHED: %s",
+              usbDevice != null ? usbDevice.getDeviceName() : "null");
 
       if (usbDevice != null) {  // paranoia
         // We might get attachment notifications before the event loop is set up, so


### PR DESCRIPTION
## Summary
- fix potential NPE when logging attached USB devices

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841854e2f288321b63ec52f01a5b122